### PR TITLE
OCM-6266: Remove "ResourceGroupsandTagEditorFullAccess" permission from shared-vpc

### DIFF
--- a/modules/shared-vpc-policy-and-hosted-zone/main.tf
+++ b/modules/shared-vpc-policy-and-hosted-zone/main.tf
@@ -5,9 +5,6 @@ locals {
 
 resource "aws_iam_role" "shared_vpc_role" {
   name = "${local.name_prefix}-shared-vpc-role"
-  managed_policy_arns = [
-    "arn:aws:iam::aws:policy/ResourceGroupsandTagEditorFullAccess"
-  ]
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [


### PR DESCRIPTION
Fixes: [OCM-6266](https://issues.redhat.com//browse/OCM-6266) 