### PR TITLE
OCM-6339: Expose availability_zones as parameter in vpc sub-module

### DIFF
--- a/examples/rosa-classic-public-with-byo-vpc/README.md
+++ b/examples/rosa-classic-public-with-byo-vpc/README.md
@@ -31,7 +31,9 @@ Installation of the following CLI tools is recommended:
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 
@@ -42,7 +44,9 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 
 ## Inputs
 

--- a/examples/rosa-classic-public-with-byo-vpc/main.tf
+++ b/examples/rosa-classic-public-with-byo-vpc/main.tf
@@ -10,6 +10,7 @@ module "rosa" {
   aws_subnet_ids         = concat(module.vpc.public_subnets, module.vpc.private_subnets)
   aws_availability_zones = module.vpc.availability_zones
   multi_az               = length(module.vpc.availability_zones) > 1
+  replicas               = 3
 }
 
 ############################
@@ -18,6 +19,16 @@ module "rosa" {
 module "vpc" {
   source = "../../modules/vpc"
 
-  name_prefix              = var.cluster_name
-  availability_zones_count = 3
+  name_prefix        = var.cluster_name
+  availability_zones = slice(data.aws_availability_zones.available.names, 0, 3)
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  # New configuration to exclude Local Zones
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
 }

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -51,7 +51,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_availability_zones_count"></a> [availability\_zones\_count](#input\_availability\_zones\_count) | The count of availability zones to utilize within the specified AWS Region, where pairs of public and private subnets will be generated. | `number` | n/a | yes |
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | A list of availability zones names or ids in the region. | `list(string)` | `null` | no |
+| <a name="input_availability_zones_count"></a> [availability\_zones\_count](#input\_availability\_zones\_count) | The count of availability zones to utilize within the specified AWS Region, where pairs of public and private subnets will be generated. Valid only when availability\_zones variable is not provided. | `number` | `null` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | User-defined prefix for all generated AWS resources of this VPC | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | AWS tags to be applied to generated AWS resources of this VPC. | `map(string)` | `null` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | Cidr block of the desired VPC. | `string` | `"10.0.0.0/16"` | no |

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -9,9 +9,16 @@ variable "name_prefix" {
   description = "User-defined prefix for all generated AWS resources of this VPC"
 }
 
+variable "availability_zones" {
+  type        = list(string)
+  default     = null
+  description = "A list of availability zones names or ids in the region."
+}
+
 variable "availability_zones_count" {
   type        = number
-  description = "The count of availability zones to utilize within the specified AWS Region, where pairs of public and private subnets will be generated."
+  default     = null
+  description = "The count of availability zones to utilize within the specified AWS Region, where pairs of public and private subnets will be generated. Valid only when availability_zones variable is not provided."
 }
 
 variable "tags" {


### PR DESCRIPTION
This Change include:
1. Adding the variable to the vpc sub-module and using it
2. Change one example (rosa-classic-public-with-byo-vpc) to provide the availability_zones variable