### PR TITLE
OCM-6406: shared vpc resources name_prefix changes

### DIFF
--- a/examples/rosa-classic-public-with-shared-vpc/main.tf
+++ b/examples/rosa-classic-public-with-shared-vpc/main.tf
@@ -8,6 +8,13 @@ provider "aws" {
   shared_credentials_files = var.shared_vpc_aws_shared_credentials_files
 }
 
+locals {
+  account_role_prefix          = "${var.cluster_name}-account"
+  operator_role_prefix         = "${var.cluster_name}-operator"
+  shared_resources_name_prefix = var.cluster_name
+  shared_vpc_role_name         = "${local.shared_resources_name_prefix}-shared-vpc-role"
+}
+
 data "aws_region" "current" {}
 
 ############################
@@ -20,14 +27,8 @@ module "vpc" {
     aws = aws.shared-vpc
   }
 
-  name_prefix              = var.cluster_name
+  name_prefix              = local.shared_resources_name_prefix
   availability_zones_count = 3
-}
-
-locals {
-  account_role_prefix  = "${var.cluster_name}-account"
-  shared_vpc_role_name = "${var.cluster_name}-shared-vpc-role"
-  operator_role_prefix = "${var.cluster_name}-operator"
 }
 
 ##############################################################
@@ -92,6 +93,7 @@ module "shared-vpc-policy-and-hosted-zone" {
   }
 
   cluster_name              = var.cluster_name
+  name_prefix               = local.shared_resources_name_prefix
   target_aws_account        = data.aws_caller_identity.current.account_id
   installer_role_arn        = module.account_iam_resources.account_roles_arn["Installer"]
   ingress_operator_role_arn = module.operator_roles.operator_roles_arn["openshift-ingress-operator"]

--- a/modules/shared-vpc-policy-and-hosted-zone/README.md
+++ b/modules/shared-vpc-policy-and-hosted-zone/README.md
@@ -47,7 +47,7 @@ No modules.
 | <a name="input_hosted_zone_base_domain"></a> [hosted\_zone\_base\_domain](#input\_hosted\_zone\_base\_domain) | The Base Domain that should be used for the Hosted Zone creation. | `string` | n/a | yes |
 | <a name="input_ingress_operator_role_arn"></a> [ingress\_operator\_role\_arn](#input\_ingress\_operator\_role\_arn) | Ingress Operator ARN from target account | `string` | n/a | yes |
 | <a name="input_installer_role_arn"></a> [installer\_role\_arn](#input\_installer\_role\_arn) | Installer ARN from target account | `string` | n/a | yes |
-| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | The prefix applied to all AWS creations. If not provided, the default is to use the cluster\_name. | `string` | `null` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | The prefix applied to all AWS creations. | `string` | n/a | yes |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | The list of the subnets that should be shared between the accounts. | `list(string)` | n/a | yes |
 | <a name="input_target_aws_account"></a> [target\_aws\_account](#input\_target\_aws\_account) | The AWS account number in where the cluster is going to be created. | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The Shared VPC ID | `string` | n/a | yes |

--- a/modules/shared-vpc-policy-and-hosted-zone/main.tf
+++ b/modules/shared-vpc-policy-and-hosted-zone/main.tf
@@ -1,10 +1,9 @@
 locals {
-  name_prefix         = var.name_prefix != null ? var.name_prefix : var.cluster_name
   resource_arn_prefix = "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:subnet/"
 }
 
 resource "aws_iam_role" "shared_vpc_role" {
-  name = "${local.name_prefix}-shared-vpc-role"
+  name = "${var.name_prefix}-shared-vpc-role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -28,7 +27,7 @@ resource "aws_iam_role" "shared_vpc_role" {
 }
 
 resource "aws_iam_policy" "shared_vpc_policy" {
-  name = "${local.name_prefix}-shared-vpc-policy"
+  name = "${var.name_prefix}-shared-vpc-policy"
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -60,7 +59,7 @@ resource "aws_iam_role_policy_attachment" "shared_vpc_role_policy_attachment" {
 }
 
 resource "aws_ram_resource_share" "shared_vpc_resource_share" {
-  name                      = "${local.name_prefix}-shared-vpc-resource-share"
+  name                      = "${var.name_prefix}-shared-vpc-resource-share"
   allow_external_principals = true
 }
 

--- a/modules/shared-vpc-policy-and-hosted-zone/variables.tf
+++ b/modules/shared-vpc-policy-and-hosted-zone/variables.tf
@@ -5,8 +5,7 @@ variable "cluster_name" {
 
 variable "name_prefix" {
   type        = string
-  default     = null
-  description = "The prefix applied to all AWS creations. If not provided, the default is to use the cluster_name."
+  description = "The prefix applied to all AWS creations."
 }
 
 variable "target_aws_account" {


### PR DESCRIPTION
* Make it required in the "shared-vpc-policy-and-hosted-zone" sub-module, without default value
* In the "rosa-classic-public-with-shared-vpc" example, use the cluser_name to define the name_prefix