### PR TITLE
OCM-6434: Fix rosa_classic_cluster sub-module

### DIFF
--- a/modules/rosa-cluster-classic/main.tf
+++ b/modules/rosa-cluster-classic/main.tf
@@ -180,7 +180,7 @@ data "aws_availability_zones" "available" {
 }
 
 data "aws_subnet" "provided_subnet" {
-  count = length(var.aws_subnet_ids)
+  count = length(var.aws_availability_zones) > 0 ? 0 : length(var.aws_subnet_ids)
 
   id = var.aws_subnet_ids[count.index]
 }


### PR DESCRIPTION
Fix details:
Avoid getting availability_zones from "aws_subnet" data source when user provided availability_zones list