### PR TITLE
OCM-6428: examples - decouple the relationship between replicas and availability zones count

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ verify:
 		echo "!! Validating $$d !!" && cd $$d && rm -rf .terraform .terraform.lock.hcl && terraform init && terraform validate && cd - ;\
 	done
 
+verify-gen: terraform-docs
+	scripts/verify-gen.sh
+
 .PHONY: tf-init
 tf-init:
 	@cd $(TERRAFORM_DIR) && terraform init -input=false -lock=false -no-color -reconfigure

--- a/examples/rosa-classic-public-with-byo-vpc-byo-iam-byo-oidc/main.tf
+++ b/examples/rosa-classic-public-with-byo-vpc-byo-iam-byo-oidc/main.tf
@@ -16,7 +16,7 @@ module "rosa" {
   aws_availability_zones = module.vpc.availability_zones
   multi_az               = length(module.vpc.availability_zones) > 1
   path                   = module.account_iam_resources.path
-  replicas               = length(module.vpc.availability_zones)
+  replicas               = 3
 }
 
 ############################

--- a/examples/rosa-classic-public-with-shared-vpc/main.tf
+++ b/examples/rosa-classic-public-with-shared-vpc/main.tf
@@ -115,7 +115,7 @@ module "rosa_cluster_classic" {
   oidc_config_id               = module.oidc_config_and_provider.oidc_config_id
   aws_subnet_ids               = module.shared-vpc-policy-and-hosted-zone.shared_subnets
   multi_az                     = length(module.vpc.availability_zones) > 1
-  replicas                     = length(module.vpc.availability_zones)
+  replicas                     = 3
   admin_credentials_username   = "kubeadmin"
   admin_credentials_password   = random_password.password.result
   base_dns_domain              = rhcs_dns_domain.dns_domain.id

--- a/modules/oidc-config-and-provider/README.md
+++ b/modules/oidc-config-and-provider/README.md
@@ -4,7 +4,7 @@
 
 This Terraform sub-module is designed to manage the OpenID Connect (OIDC) provider and configuration for Red Hat OpenShift Service on AWS (ROSA) clusters. It allows users to define and configure the OIDC provider settings necessary for authentication within the ROSA cluster environment. With this module, users can easily set up OIDC integration tailored to their requirements, enabling seamless authentication and access control mechanisms for ROSA clusters deployed on AWS.
 
-For more info see [About IAM resources for ROSA clusters that use STS](https://docs.openshift.com/rosa/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-sts-about-iam-resources)
+For more info see [OpenID Connect Overview](https://docs.openshift.com/rosa/rosa_architecture/rosa-oidc-overview.html)
 
 <!-- BEGIN_AUTOMATED_TF_DOCS_BLOCK -->
 ## Requirements

--- a/scripts/verify-gen.sh
+++ b/scripts/verify-gen.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -xe
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "It seems like you need to run 'make terraform-docs'. Please run it and commit the changes"
+    git status --porcelain
+    exit 1
+fi


### PR DESCRIPTION
Also include:
* OIDC link fix
* Add verify-gen makefile target