### PR TITLE
OCM-10689 | fix: use ternary instead of coalesce

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ module "operator_policies" {
   path                = var.create_account_roles ? module.account_iam_resources[0].path : local.path
   openshift_version   = var.openshift_version
   tags                = var.tags
-  shared_vpc_role_arn = coalesce(local.shared_vpc_role_arn, "")
+  shared_vpc_role_arn = local.shared_vpc_role_arn != null ? local.shared_vpc_role_arn : ""
 }
 
 ############################


### PR DESCRIPTION
Coalesce does not work for empty strings for TF, using ternary instead
[OCM-10689](https://issues.redhat.com//browse/OCM-10689)
#96 