### PR TITLE
OCM-13503 | feat: ROSA GovCloud Support

### DIFF
--- a/modules/operator-policies/README.md
+++ b/modules/operator-policies/README.md
@@ -55,6 +55,7 @@ No modules.
 | [aws_iam_policy.operator-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [null_resource.validate_openshift_version](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [time_sleep.operator_policy_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [rhcs_info.current](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/data-sources/info) | data source |
 | [rhcs_policies.all_policies](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/data-sources/policies) | data source |
 | [rhcs_versions.all_versions](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/data-sources/versions) | data source |
 

--- a/modules/operator-roles/README.md
+++ b/modules/operator-roles/README.md
@@ -64,6 +64,7 @@ No modules.
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.custom_trust_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [rhcs_info.current](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/data-sources/info) | data source |
 | [rhcs_rosa_operator_roles.operator_roles](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs/data-sources/rosa_operator_roles) | data source |
 
 ## Inputs

--- a/modules/operator-roles/main.tf
+++ b/modules/operator-roles/main.tf
@@ -3,8 +3,9 @@ locals {
   # the planning stage (at first apply).
   # Therefore, the "operator_roles_count" local variable introduced with a hardcoded value.
   # Validation within the "rhcs_rosa_operator_roles.operator_roles" data source ensures that this
-  # value matches the actual length returned from the data source.
-  operator_roles_count = 6
+  # value matches the actual length returned from the data source. Must use a toggle to add
+  # an additional role for GovCloud accounts.
+  operator_roles_count = strcontains(data.rhcs_info.current.ocm_api, "gov") ? 7 : 6
   operator_role_prefix = (var.operator_role_prefix != null && var.operator_role_prefix != "") ? var.operator_role_prefix : var.account_role_prefix
   path                 = coalesce(var.path, "/")
 }
@@ -55,7 +56,7 @@ data "rhcs_rosa_operator_roles" "operator_roles" {
   account_role_prefix  = var.account_role_prefix
 
   lifecycle {
-    # The operator_iam_roles should contains 6 elements 
+    # The operator_iam_roles should contains 6 elements (or 7 for GovCloud installations)
     postcondition {
       condition     = length(self.operator_iam_roles) == local.operator_roles_count
       error_message = "The operator roles list returned has a length of ${length(self.operator_iam_roles)}, which differs from the expected value of ${local.operator_roles_count}. To solve this, you need to update \"local.operator_roles_count\" value to ${length(self.operator_iam_roles)} and apply again."
@@ -77,3 +78,5 @@ resource "time_sleep" "role_resources_propagation" {
 }
 
 data "aws_partition" "current" {}
+
+data "rhcs_info" "current" {}


### PR DESCRIPTION
This PR introduces support for ROSA GovCloud environments. In GovCloud, there is an extra operator role not needed in commercial environments: `openshift_aws_vpce_operator_avo_aws_creds_policy`

I've added a toggle to ensure the role is only leveraged when "gov" is present in the `ocm_api` being used with the `rhcs` provider.

Having good data returned depends on this PR to be merged: https://github.com/terraform-redhat/terraform-provider-rhcs/pull/867 

