### PR TITLE
OCM-15763 | feat: Introduce govcloud var + update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ We recommend you install the following CLI tools:
 | <a name="input_ec2_metadata_http_tokens"></a> [ec2\_metadata\_http\_tokens](#input\_ec2\_metadata\_http\_tokens) | Should cluster nodes use both v1 and v2 endpoints or just v2 endpoint of EC2 Instance Metadata Service (IMDS). Available since OpenShift 4.11.0. | `string` | `null` | no |
 | <a name="input_etcd_encryption"></a> [etcd\_encryption](#input\_etcd\_encryption) | Add etcd encryption. By default, etcd data is encrypted at rest. This option configures etcd encryption on top of existing storage encryption. | `bool` | `null` | no |
 | <a name="input_fips"></a> [fips](#input\_fips) | Create cluster that uses FIPS Validated / Modules in Process cryptographic libraries. | `bool` | `null` | no |
+| <a name="input_govcloud"></a> [govcloud](#input\_govcloud) | Whether or not resources are to be used in a Govcloud environment. | `bool` | `false` | no |
 | <a name="input_host_prefix"></a> [host\_prefix](#input\_host\_prefix) | Subnet prefix length to assign to each individual node. For example, if host prefix is set to "23", then each node is assigned a /23 subnet out of the given CIDR. | `number` | `null` | no |
 | <a name="input_http_proxy"></a> [http\_proxy](#input\_http\_proxy) | A proxy URL to use for creating HTTP connections outside the cluster. The URL scheme must be http. | `string` | `null` | no |
 | <a name="input_https_proxy"></a> [https\_proxy](#input\_https\_proxy) | A proxy URL to use for creating HTTPS connections outside the cluster. | `string` | `null` | no |

--- a/examples/rosa-classic-private-with-autoscaler-unmanaged-oidc-byo-vpc/main.tf
+++ b/examples/rosa-classic-private-with-autoscaler-unmanaged-oidc-byo-vpc/main.tf
@@ -19,6 +19,7 @@ module "rosa" {
   multi_az                   = length(module.vpc.availability_zones) > 1
   cluster_autoscaler_enabled = true
   autoscaler_log_verbosity   = 4
+  govcloud                   = false
 }
 
 ############################

--- a/examples/rosa-classic-public-with-byo-vpc-byo-iam-byo-oidc/main.tf
+++ b/examples/rosa-classic-public-with-byo-vpc-byo-iam-byo-oidc/main.tf
@@ -17,6 +17,7 @@ module "rosa" {
   multi_az               = length(module.vpc.availability_zones) > 1
   path                   = module.account_iam_resources.path
   replicas               = 3
+  govcloud               = false
 }
 
 ############################

--- a/examples/rosa-classic-public-with-byo-vpc/main.tf
+++ b/examples/rosa-classic-public-with-byo-vpc/main.tf
@@ -11,6 +11,7 @@ module "rosa" {
   aws_availability_zones = module.vpc.availability_zones
   multi_az               = length(module.vpc.availability_zones) > 1
   replicas               = 3
+  govcloud               = false
 }
 
 ############################

--- a/examples/rosa-classic-public-with-idp-machine-pools/main.tf
+++ b/examples/rosa-classic-public-with-idp-machine-pools/main.tf
@@ -6,6 +6,7 @@ module "rosa" {
   create_account_roles  = true
   create_operator_roles = true
   create_oidc           = true
+  govcloud              = false
 }
 
 module "machine_pool_1" {

--- a/examples/rosa-classic-public-with-multiple-machinepools-and-idps/main.tf
+++ b/examples/rosa-classic-public-with-multiple-machinepools-and-idps/main.tf
@@ -6,6 +6,7 @@ module "rosa" {
   create_account_roles  = true
   create_operator_roles = true
   create_oidc           = true
+  govcloud              = false
   machine_pools = {
     pool1 = {
       name         = "pool1"

--- a/examples/rosa-classic-public-with-unmanaged-oidc/main.tf
+++ b/examples/rosa-classic-public-with-unmanaged-oidc/main.tf
@@ -7,4 +7,5 @@ module "rosa" {
   create_operator_roles = true
   create_oidc           = true
   managed_oidc          = false
+  govcloud              = false
 }

--- a/examples/rosa-classic-public/main.tf
+++ b/examples/rosa-classic-public/main.tf
@@ -8,5 +8,6 @@ module "rosa" {
   create_oidc           = true
   create_admin_user     = true
   path                  = "/tf-example/"
+  govcloud              = false
 }
 

--- a/main.tf
+++ b/main.tf
@@ -68,6 +68,7 @@ module "operator_roles" {
   oidc_endpoint_url    = var.create_oidc ? module.oidc_config_and_provider[0].oidc_endpoint_url : var.oidc_endpoint_url
   tags                 = var.tags
   permissions_boundary = var.permissions_boundary
+  govcloud             = var.govcloud
 
   depends_on = [module.operator_policies]
 }

--- a/modules/operator-roles/README.md
+++ b/modules/operator-roles/README.md
@@ -72,6 +72,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_role_prefix"></a> [account\_role\_prefix](#input\_account\_role\_prefix) | User-defined prefix for all generated AWS resources. | `string` | n/a | yes |
+| <a name="input_govcloud"></a> [govcloud](#input\_govcloud) | Whether or not resources are to be used in a Govcloud environment. | `bool` | `false` | no |
 | <a name="input_oidc_endpoint_url"></a> [oidc\_endpoint\_url](#input\_oidc\_endpoint\_url) | Registered OIDC configuration issuer URL, added as the trusted relationship to the operator roles. | `string` | n/a | yes |
 | <a name="input_operator_role_prefix"></a> [operator\_role\_prefix](#input\_operator\_role\_prefix) | User-defined prefix for generated AWS operator policies. Use "account-role-prefix" in case no value provided. | `string` | `null` | no |
 | <a name="input_path"></a> [path](#input\_path) | The ARN path for the account/operator roles as well as their policies. Must use the same path used for "account\_iam\_roles". | `string` | `"/"` | no |

--- a/modules/operator-roles/main.tf
+++ b/modules/operator-roles/main.tf
@@ -1,11 +1,5 @@
 locals {
-  # The "count" value should not rely on data source outputs that are undetermined during
-  # the planning stage (at first apply).
-  # Therefore, the "operator_roles_count" local variable introduced with a hardcoded value.
-  # Validation within the "rhcs_rosa_operator_roles.operator_roles" data source ensures that this
-  # value matches the actual length returned from the data source. Must use a toggle to add
-  # an additional role for GovCloud accounts.
-  operator_roles_count = strcontains(data.rhcs_info.current.ocm_api, "gov") ? 7 : 6
+  operator_roles_count = (var.govcloud == true) ? 7 : 6
   operator_role_prefix = (var.operator_role_prefix != null && var.operator_role_prefix != "") ? var.operator_role_prefix : var.account_role_prefix
   path                 = coalesce(var.path, "/")
 }

--- a/modules/operator-roles/variables.tf
+++ b/modules/operator-roles/variables.tf
@@ -31,3 +31,9 @@ variable "oidc_endpoint_url" {
   type        = string
   description = "Registered OIDC configuration issuer URL, added as the trusted relationship to the operator roles."
 }
+
+variable "govcloud" {
+  type = bool
+  default = false
+  description = "Whether or not resources are to be used in a Govcloud environment."
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -83,4 +83,3 @@ output "operator_roles_arn" {
   value       = var.create_operator_roles ? module.operator_roles[0].operator_roles_arn : null
   description = "List of Amazon Resource Names (ARNs) for all operator roles created."
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -543,3 +543,9 @@ variable "identity_providers" {
   default     = {}
   description = "Provides a generic approach to add multiple identity providers after the creation of the cluster. This variable allows users to specify configurations for multiple identity providers in a flexible and customizable manner, facilitating the management of resources post-cluster deployment. For additional details regarding the variables utilized, refer to the [idp sub-module](./modules/idp). For non-primitive variables (such as maps, lists, and objects), supply the JSON-encoded string."
 }
+
+variable "govcloud" {
+  type = bool
+  default = false
+  description = "Whether or not resources are to be used in a Govcloud environment."
+}


### PR DESCRIPTION
* Introduces `govcloud` var for the `operator-roles` module
  * This allows the user to influence the operator role count var, since we cannot use the datasource like normal for govcloud
* Updated docs using make command