### PR TITLE
Make 'aws_additional_security_group_ids' optional

### DIFF
--- a/modules/machine-pool/variables.tf
+++ b/modules/machine-pool/variables.tf
@@ -94,6 +94,5 @@ variable "disk_size" {
 
 variable "aws_additional_security_group_ids" {
   description = "AWS additional security group IDs."
-  type        = list(string)
-  default     = null
+  type        = optional(list(string))
 }


### PR DESCRIPTION
The RHCS provider defines the 'aws_additional_security_group_ids' attribute as optional in the 'rhcs_machine_pool' resource. Using optional(list(string)) in the variable definition aligns with the provider's schema and prevents potential type mismatches.

In the ROSA HCP repository this same change was made to align with the provider's optional attribute definition, so this commit keeps the consistency between the two implementations.

This change should be backwards compatible as existing configurations that don't specify this variable will continue to work and configurations that explicitly set the variable to null or omit it will work the same way.