### PR TITLE
Changing data source aws_region.current.name to aws_region.current.re…

### DIFF
--- a/examples/rosa-classic-public-with-shared-vpc/README.md
+++ b/examples/rosa-classic-public-with-shared-vpc/README.md
@@ -30,7 +30,7 @@ provider "aws" {
 
   access_key               = "<shared_vpc_aws_access_key_id>"
   secret_key               = "<shared_vpc_aws_secret_access_key>"
-  region                   = data.aws_region.current.name
+  region                   = data.aws_region.current.region
   profile                  = "<shared_vpc_aws_profile>"
   shared_credentials_files = "<shared_vpc_aws_shared_credentials_files>"
 }

--- a/examples/rosa-classic-public-with-shared-vpc/main.tf
+++ b/examples/rosa-classic-public-with-shared-vpc/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 
   access_key               = var.shared_vpc_aws_access_key_id
   secret_key               = var.shared_vpc_aws_secret_access_key
-  region                   = data.aws_region.current.name
+  region                   = data.aws_region.current.region
   profile                  = var.shared_vpc_aws_profile
   shared_credentials_files = var.shared_vpc_aws_shared_credentials_files
 }

--- a/modules/oidc-config-and-provider/main.tf
+++ b/modules/oidc-config-and-provider/main.tf
@@ -61,7 +61,7 @@ data "aws_iam_policy_document" "allow_access_from_another_account" {
 resource "rhcs_rosa_oidc_config_input" "oidc_input" {
   count = var.managed ? 0 : 1
 
-  region = data.aws_region.current.name
+  region = data.aws_region.current.region
 }
 
 module "aws_secrets_manager" {

--- a/modules/rosa-cluster-classic/main.tf
+++ b/modules/rosa-cluster-classic/main.tf
@@ -38,7 +38,7 @@ locals {
 
 resource "rhcs_cluster_rosa_classic" "rosa_classic_cluster" {
   name           = var.cluster_name
-  cloud_region   = var.aws_region == null ? data.aws_region.current[0].name : var.aws_region
+  cloud_region   = var.aws_region == null ? data.aws_region.current[0].region : var.aws_region
   aws_account_id = local.aws_account_id
   replicas       = var.replicas
   version        = var.openshift_version

--- a/modules/shared-vpc-policy-and-hosted-zone/main.tf
+++ b/modules/shared-vpc-policy-and-hosted-zone/main.tf
@@ -1,5 +1,5 @@
 locals {
-  resource_arn_prefix = "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:subnet/"
+  resource_arn_prefix = "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:subnet/"
 }
 
 resource "aws_iam_role" "shared_vpc_role" {

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -20,7 +20,7 @@ resource "aws_vpc" "vpc" {
 
 resource "aws_vpc_endpoint" "s3" {
   vpc_id       = aws_vpc.vpc.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 }
 
 resource "aws_subnet" "public_subnet" {


### PR DESCRIPTION
…gion as name is deprecated - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region