### PR TITLE
Fix terraform init, by limit the account-iam-resources module below v6.0

### DIFF
--- a/modules/account-iam-resources/main.tf
+++ b/modules/account-iam-resources/main.tf
@@ -61,7 +61,7 @@ data "aws_iam_policy_document" "custom_trust_policy" {
 
 module "account_iam_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = ">=5.34.0"
+  version = ">=5.34.0, < 6.0"
 
   count = local.account_roles_count
 


### PR DESCRIPTION
Recently began to observe the following error during terraform init:
```
╷
│ Error: Unreadable module subdirectory
│ 
│ The directory
│ .terraform/modules/rosa_cluster_classic.account_iam_resources.account_iam_role/modules/iam-assumable-role
│ does not exist. The target submodule modules/iam-assumable-role does not
│ exist within the target module.
╵
```
That's because in v6 of `terraform-aws-iam` ([module](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/v6.0.0/modules)) the `iam-assumable-role` is missing completely. 

This is only a temporary fix until a proper review and update is done. 