### PR TITLE
ROSAENG-66713 | fix(oidc): replace upstream s3-bucket module with inline resources

### DIFF
--- a/modules/oidc-config-and-provider/README.md
+++ b/modules/oidc-config-and-provider/README.md
@@ -40,7 +40,6 @@ module "oidc_config_and_provider" {
 
 | Name | Source | Version |
 | ---- | ------ | ------- |
-| <a name="module_aws_s3_bucket"></a> [aws\_s3\_bucket](#module\_aws\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | = 4.11.0 |
 | <a name="module_aws_secrets_manager"></a> [aws\_secrets\_manager](#module\_aws\_secrets\_manager) | terraform-aws-modules/secrets-manager/aws | 1.3.1 |
 
 ## Resources
@@ -48,6 +47,9 @@ module "oidc_config_and_provider" {
 | Name | Type |
 | ---- | ---- |
 | [aws_iam_openid_connect_provider.oidc_provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
+| [aws_s3_bucket.oidc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_policy.oidc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.oidc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_object.discrover_doc_object](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
 | [aws_s3_object.s3_object](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
 | [null_resource.unmanaged_vars_validation](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |

--- a/modules/oidc-config-and-provider/main.tf
+++ b/modules/oidc-config-and-provider/main.tf
@@ -21,25 +21,48 @@ resource "aws_iam_openid_connect_provider" "oidc_provider" {
   thumbprint_list = [rhcs_rosa_oidc_config.oidc_config.thumbprint]
 }
 
-module "aws_s3_bucket" {
-  source = "terraform-aws-modules/s3-bucket/aws"
-  # Exact pin: avoid upstream 5.x raising merged AWS provider floors for customers — bump manually when needed.
-  version = "= 4.11.0"
-
+resource "aws_s3_bucket" "oidc" {
   count = var.managed ? 0 : 1
 
   bucket = rhcs_rosa_oidc_config_input.oidc_input[count.index].bucket_name
   tags = merge(var.tags, {
     red-hat-managed = true
   })
+}
+
+resource "aws_s3_bucket_public_access_block" "oidc" {
+  count = var.managed ? 0 : 1
+
+  bucket = aws_s3_bucket.oidc[count.index].id
 
   block_public_acls       = true
   ignore_public_acls      = true
   block_public_policy     = false
   restrict_public_buckets = false
+}
 
-  attach_policy = true
-  policy        = data.aws_iam_policy_document.allow_access_from_another_account[count.index].json
+resource "aws_s3_bucket_policy" "oidc" {
+  count = var.managed ? 0 : 1
+
+  bucket = aws_s3_bucket.oidc[count.index].id
+  policy = data.aws_iam_policy_document.allow_access_from_another_account[count.index].json
+
+  depends_on = [aws_s3_bucket_public_access_block.oidc]
+}
+
+moved {
+  from = module.aws_s3_bucket[0].aws_s3_bucket.this[0]
+  to   = aws_s3_bucket.oidc[0]
+}
+
+moved {
+  from = module.aws_s3_bucket[0].aws_s3_bucket_public_access_block.this[0]
+  to   = aws_s3_bucket_public_access_block.oidc[0]
+}
+
+moved {
+  from = module.aws_s3_bucket[0].aws_s3_bucket_policy.this[0]
+  to   = aws_s3_bucket_policy.oidc[0]
 }
 
 data "aws_iam_policy_document" "allow_access_from_another_account" {
@@ -90,7 +113,7 @@ module "aws_secrets_manager" {
 resource "aws_s3_object" "discrover_doc_object" {
   count = var.managed ? 0 : 1
 
-  bucket       = module.aws_s3_bucket[count.index].s3_bucket_id
+  bucket       = aws_s3_bucket.oidc[count.index].id
   key          = ".well-known/openid-configuration"
   content      = rhcs_rosa_oidc_config_input.oidc_input[count.index].discovery_doc
   content_type = "application/json"
@@ -103,7 +126,7 @@ resource "aws_s3_object" "discrover_doc_object" {
 resource "aws_s3_object" "s3_object" {
   count = var.managed ? 0 : 1
 
-  bucket       = module.aws_s3_bucket[count.index].s3_bucket_id
+  bucket       = aws_s3_bucket.oidc[count.index].id
   key          = "keys.json"
   content      = rhcs_rosa_oidc_config_input.oidc_input[count.index].jwks
   content_type = "application/json"

--- a/modules/oidc-config-and-provider/tests/validation.tftest.hcl
+++ b/modules/oidc-config-and-provider/tests/validation.tftest.hcl
@@ -4,7 +4,7 @@
 mock_provider "aws" {
   mock_data "aws_region" {
     defaults = {
-      name = "us-east-1"
+      region = "us-east-1"
     }
   }
 
@@ -44,6 +44,53 @@ mock_provider "null" {
     defaults = {
       id = "mock-null"
     }
+  }
+}
+
+run "managed_true_skips_s3_resources" {
+  command = plan
+
+  variables {
+    managed = true
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket.oidc) == 0
+    error_message = "S3 bucket must not be created when managed is true."
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket_public_access_block.oidc) == 0
+    error_message = "S3 public access block must not be created when managed is true."
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket_policy.oidc) == 0
+    error_message = "S3 bucket policy must not be created when managed is true."
+  }
+}
+
+run "managed_false_creates_s3_resources" {
+  command = plan
+
+  variables {
+    managed            = false
+    installer_role_arn = "arn:aws:iam::123456789012:role/mock-installer"
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket.oidc) == 1
+    error_message = "S3 bucket must be created when managed is false."
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket_public_access_block.oidc) == 1
+    error_message = "S3 public access block must be created when managed is false."
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket_policy.oidc) == 1
+    error_message = "S3 bucket policy must be created when managed is false."
   }
 }
 


### PR DESCRIPTION
## PR Summary

Replace the third-party `terraform-aws-modules/s3-bucket/aws` v4.11.0 module in `oidc-config-and-provider` with inline AWS resources to eliminate `data.aws_region.current.name` deprecation warnings on AWS provider 6.x.

## Detailed Description of the Issue

The upstream `terraform-aws-modules/s3-bucket/aws` module at v4.11.0 uses `data.aws_region.current.name` internally, which is deprecated in AWS provider 6.x (replaced by `.region`). This causes deprecation warnings during `make pre-push-checks` (specifically `terraform validate`). No 4.x release of the upstream module fixes this. The 5.x line does use `.region`, but it raises the Terraform floor to `>= 1.10`, which would break consumers on Terraform 1.5.7–1.9.x (the root module floor is `>= 1.5.7`).

The fix replaces the third-party module with three direct AWS resources (`aws_s3_bucket`, `aws_s3_bucket_public_access_block`, `aws_s3_bucket_policy`), which avoids raising any version floors and aligns with the project guideline in `developer-docs/submodules.md` to use direct `aws_*` resources over community wrappers.

## Related Issues and PRs

- Fixes: [ROSAENG-66713](https://redhat.atlassian.net/browse/ROSAENG-66713)

## Type of Change

- [ ] feat - adds a new module capability or new user-facing behavior.
- [x] fix - resolves incorrect module behavior or bug.
- [ ] docs - updates documentation only.
- [ ] style - formatting/naming changes with no logic impact.
- [ ] refactor - module code restructuring with no behavior change.
- [ ] test - adds or updates tests only.
- [ ] chore - maintenance work (tooling, housekeeping, non-product code).
- [ ] build - changes build system, packaging, or dependencies for build output.
- [ ] ci - changes CI pipelines, jobs, or automation workflows.
- [ ] perf - improves performance without changing intended behavior.

## Previous Behavior

Running `make pre-push-checks` emitted deprecation warnings:

```
Warning: Deprecated value used
  with module.rosa.module.oidc_config_and_provider.module.aws_s3_bucket.data.aws_iam_policy_document.waf_log_delivery,
  on .terraform/modules/rosa.oidc_config_and_provider.aws_s3_bucket/main.tf line 825
  Deprecated resource attribute "name" used. Refer to the provider documentation for details.
```

## Behavior After This Change

`terraform validate` and `make pre-push-checks` complete without deprecation warnings. No provider or Terraform version floor changes are introduced.

## How to Test (Step-by-Step)

### Preconditions

- Terraform >= 1.5.7
- AWS provider >= 6.0.0

### Test Steps

1. Run `make unit-tests` — all module tests should pass (4 tests for `oidc-config-and-provider`).
2. Run `cd modules/oidc-config-and-provider && terraform init -backend=false && terraform validate` — should report no warnings.
3. Run `make pre-push-checks` — should pass without deprecation warnings.
4. For existing deployments: run `terraform plan` — the `moved` blocks should show zero resource changes (state migration only).

### Expected Results

- No deprecation warnings from `data.aws_region.current.name`.
- Existing S3 bucket, public access block, and bucket policy resources are migrated in state via `moved` blocks — no destroy/recreate.
- New plan-level tests confirm S3 resources are created when `managed = false` (count 1) and skipped when `managed = true` (count 0).

## Proof of the Fix

- `terraform validate` output: `Success! The configuration is valid.` (no warnings)
- `make unit-tests` output: `4 passed, 0 failed` for `oidc-config-and-provider`

## Breaking Changes

- [x] No breaking changes

### Breaking Change Details / Migration Plan

N/A — `moved` blocks handle state migration automatically. No variable, output, or provider floor changes.

## Developer Verification Checklist

- [x] **AWS-only changes:** This PR replaces a third-party S3 module with direct `aws_*` resources, consistent with [`developer-docs/submodules.md`](developer-docs/submodules.md) guidance to use first-party resources.
- [x] I checked if this affects terraform-rhcs-rosa-hcp and submitted (or already submitted) a companion PR when needed.
- [x] Commit subject/title follows `[JIRA-TICKET] | [TYPE]: <MESSAGE>`.
- [x] PR description clearly explains both **what** changed and **why**.
- [x] Relevant Jira/GitHub issues and related PRs are linked.
- [x] Tests were added/updated where appropriate.
- [x] I manually tested the change.
- [x] `make pre-push-checks` passes (or each step: `verify`, `verify-gen`, `lint`, `unit-tests`, `license-check`, `docs-lint`).
- [x] Documentation was added/updated where appropriate (see `make terraform-docs`).
- [x] Any risk, limitation, or follow-up work is documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated module documentation to describe OIDC storage, bucket policy, and public-access settings.

- **Infrastructure**
  - Replaced the previous S3 implementation with native AWS storage resources while preserving conditional creation and access policies.
  - Maintained existing state through resource migration support.
  - Updated OIDC document storage to use the managed bucket resources.

- **Tests**
  - Corrected the mocked AWS region attribute.
  - Added coverage confirming managed and unmanaged configurations create the expected storage resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->